### PR TITLE
INFRA-1451 - Small updates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@
 hdfs_cluster_name: cluster1
 hdfs_user: hdfs
 hdfs_group: hadoop
+hdfs_user_home: "/var/lib/{{ hdfs_user }}"
 hdfs_version: 2.7.3
 
 hdfs_java_home: /usr/lib/jvm/java-1.8.0-openjdk-amd64
@@ -20,7 +21,7 @@ hdfs_ansible_handlers: True
 hdfs_redistribute_ssh_keys: False
 
 hdfs_parent_dir: /usr/local  # hadoop binaries will be copied here
-hdfs_ssh_known_hosts_file: "/home/{{hdfs_user}}/.ssh/known_hosts"
+hdfs_ssh_known_hosts_file: "{{ hdfs_user_home }}/.ssh/known_hosts"
 
 #------------------------------------------------------------------------------
 # Hadoop installation source

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,7 @@ hdfs_ssh_known_hosts_file: "/home/{{hdfs_user}}/.ssh/known_hosts"
 # Hadoop installation source
 #------------------------------------------------------------------------------
 hdfs_distribution_method: "download"   # Method to use for archive installation ("download", "local_file" or "compile")
-hdfs_download_url: "http://mirror.switch.ch/mirror/apache/dist/hadoop/common/hadoop-{{ hdfs_version }}/hadoop-{{ hdfs_version }}.tar.gz"
+hdfs_download_url: "https://archive.apache.org/dist/hadoop/core/hadoop-{{ hdfs_version }}/hadoop-{{ hdfs_version }}.tar.gz"
 hdfs_local_archive_path: "./"
 
 #------------------------------------------------------------------------------

--- a/tasks/ssh_fence.yml
+++ b/tasks/ssh_fence.yml
@@ -8,23 +8,23 @@
   set_fact: distribute_keys={{not host_file_status.stat.exists or hdfs_redistribute_ssh_keys or created_user.changed}}
 
 - name: Fetch private key
-  fetch: src=/home/{{hdfs_user}}/.ssh/id_rsa dest=rsa_key
+  fetch: src={{ hdfs_user_home }}/.ssh/id_rsa dest=rsa_key
   when: inventory_hostname == hdfs_namenodes[0] and distribute_keys
 
 - name: Fetch public key
-  fetch: src=/home/{{hdfs_user}}/.ssh/id_rsa.pub dest=rsa_key
+  fetch: src={{ hdfs_user_home }}/.ssh/id_rsa.pub dest=rsa_key
   when: inventory_hostname == hdfs_namenodes[0] and distribute_keys
 
 - name: Create .ssh directory for {{hdfs_user}}
-  file: path=/home/{{hdfs_user}}/.ssh state=directory owner={{hdfs_user}} group={{hdfs_group}} mode=0700
+  file: path={{ hdfs_user_home }}/.ssh state=directory owner={{hdfs_user}} group={{hdfs_group}} mode=0700
   when: distribute_keys
 
 - name: Copy private key to all machines
-  copy: src=rsa_key/{{hdfs_namenodes[0]}}/home/{{hdfs_user}}/.ssh/id_rsa dest=/home/{{hdfs_user}}/.ssh/id_rsa owner={{hdfs_user}} group={{hdfs_group}} mode=0600
+  copy: src=rsa_key/{{hdfs_namenodes[0]}}{{ hdfs_user_home }}/.ssh/id_rsa dest={{ hdfs_user_home }}/.ssh/id_rsa owner={{hdfs_user}} group={{hdfs_group}} mode=0600
   when: distribute_keys
 
 - name: Add pubkeys to master server
-  authorized_key: user={{hdfs_user}} key="{{ lookup('file', 'rsa_key/{{hdfs_namenodes[0]}}/home/{{hdfs_user}}/.ssh/id_rsa.pub') }}"
+  authorized_key: user={{hdfs_user}} key="{{ lookup('file', 'rsa_key/{{hdfs_namenodes[0]}}{{ hdfs_user_home }}/.ssh/id_rsa.pub') }}"
   when: distribute_keys
 
 - name: Make sure the known hosts file exists

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -7,7 +7,7 @@
   when: inventory_hostname == hdfs_namenodes[0]
 
 - name: Create user on all machines
-  user: name={{hdfs_user}} comment="Hadoop superuser" uid=1040 group={{hdfs_group}} createhome=yes
+  user: name={{hdfs_user}} comment="Hadoop superuser" uid=1040 group={{hdfs_group}} home={{ hdfs_user_home }} shell=/sbin/nologin createhome=yes
   register: created_user
 
 - include: ssh_fence.yml

--- a/templates/hdfs-site.xml.j2
+++ b/templates/hdfs-site.xml.j2
@@ -60,7 +60,7 @@
   </property>
    <property>
     <name>dfs.ha.fencing.ssh.private-key-files</name>
-    <value>/home/{{ hdfs_user }}/.ssh/id_rsa</value>
+    <value>{{ hdfs_user_home }}/.ssh/id_rsa</value>
   </property>
 {% else %}
   <property>


### PR DESCRIPTION
Refine HDFS user.
- Allow specifying/overriding home directory
- Use `nologin` as shell

Change URL for distribution, the archive contains all versions including the latest released. The main URL contains just the latest versions of active branches.