### PR TITLE
Remove snappy media player

### DIFF
--- a/tasks/native.yml
+++ b/tasks/native.yml
@@ -18,7 +18,6 @@
   - "libssl-dev"
   - "bzip2"
   - "libbz2-dev"
-  - "snappy"
   - "libsnappy-dev"
 
 - name: Copy Hadoop .tgz to {{hdfs_parent_dir}} and unpack it


### PR DESCRIPTION
Title says it all:

https://packages.ubuntu.com/trusty/snappy
https://packages.ubuntu.com/xenial/snappy